### PR TITLE
Add Metadata Remover to metadata extraction tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1200,6 +1200,8 @@ python photon.py -u https://target.com \
 
 ## 23. Metadata Extraction
 
+- [Metadata Remover](https://metadataremover.ai/metadata-viewer) — Browser-based EXIF, GPS, XMP and IPTC viewer for JPG, PNG and WebP files; keep forensic originals unchanged.
+
 **Complete suite:**
 
 | Tool | File Type | URL | Platform |


### PR DESCRIPTION
I maintain Metadata Remover.

This adds one concise browser-based metadata viewer to section 23, following the repository’s contribution format. It supports JPG, PNG and WebP metadata inspection and notes that forensic originals should remain unchanged.

No other sections are modified.